### PR TITLE
Link to b2 on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-dev libssl-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev e2fslibs-dev cmake
+          sudo apt-get install -y libxml2-dev libssl-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev libb2-dev e2fslibs-dev cmake
 
       # Install libarchive on macOS
       - name: Install libarchive (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-dev libssl-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev e2fslibs-dev cmake
+          sudo apt-get install -y libxml2-dev libssl-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev libb2-dev e2fslibs-dev cmake
 
       # Install libarchive on macOS
       - name: Install libarchive (macOS)
@@ -184,7 +184,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-dev libssl-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev e2fslibs-dev cmake
+          sudo apt-get install -y libxml2-dev libssl-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev libb2-dev e2fslibs-dev cmake
 
       # Install libarchive on macOS
       - name: Install libarchive (macOS)
@@ -239,7 +239,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-dev libssl-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev e2fslibs-dev cmake
+          sudo apt-get install -y libxml2-dev libssl-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev libb2-dev e2fslibs-dev cmake
 
       - name: Check documentation
         run: cargo doc --no-deps --all-features
@@ -282,7 +282,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxml2-dev libssl-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev e2fslibs-dev cmake
+          sudo apt-get install -y libxml2-dev libssl-dev libacl1-dev liblzma-dev libzstd-dev liblz4-dev libbz2-dev zlib1g-dev libb2-dev e2fslibs-dev cmake
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ cargo build
 
 ```bash
 sudo apt-get install build-essential cmake pkg-config \
-    zlib1g-dev libbz2-dev liblzma-dev libzstd-dev liblz4-dev
+    zlib1g-dev libbz2-dev liblzma-dev libzstd-dev liblz4-dev libb2-dev
 ```
 
 **Native Build Prerequisites (Fedora/RHEL):**
 
 ```bash
 sudo dnf install gcc-c++ cmake pkgconf \
-    zlib-devel bzip2-devel xz-devel libzstd-devel lz4-devel
+    zlib-devel bzip2-devel xz-devel libzstd-devel lz4-devel libb2-devel
 ```
 
 **Native Build:**

--- a/libarchive2-sys/build.rs
+++ b/libarchive2-sys/build.rs
@@ -281,6 +281,7 @@ fn build_libarchive() {
     } else if target.contains("linux") {
         // Linux
         println!("cargo:rustc-link-lib=pthread");
+        println!("cargo:rustc-link-lib=b2");
         println!("cargo:rustc-link-lib=z");
         println!("cargo:rustc-link-lib=bz2");
         println!("cargo:rustc-link-lib=lzma");


### PR DESCRIPTION
Without this running `cargo run --example extract_archive` fails with:

```
   Compiling libarchive2 v0.2.0 (/home/tyilo/repos/libarchive-rs)
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-m64" "/tmp/rustcE8sZir/symbols.o" "<51 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "/home/tyilo/repos/libarchive-rs/target/debug/deps/{liblibarchive2-6e03fb13ec126750,liblibarchive2_sys-bbcb817752eb0f6a}.rlib" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libstd-*,libpanic_unwind-*,libobject-*,libmemchr-*,libaddr2line-*,libgimli-*,librustc_demangle-*,libstd_detect-*,libhashbrown-*,librustc_std_workspace_alloc-*,libminiz_oxide-*,libadler2-*,libunwind-*,libcfg_if-*,liblibc-*,librustc_std_workspace_core-*,liballoc-*,libcore-*,libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lpthread" "-lz" "-lbz2" "-llzma" "-lzstd" "-llz4" "-lxml2" "-lcrypto" "-lacl" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "/tmp/rustcE8sZir/raw-dylibs" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/tyilo/repos/libarchive-rs/target/debug/build/libarchive2-sys-3fbb17994be5bfd6/out/build/libarchive" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/tyilo/repos/libarchive-rs/target/debug/examples/extract_archive-c4143c9d8447e505" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: rust-lld: error: undefined symbol: blake2sp_init
          >>> referenced by archive_read_support_format_rar5.c:873 (/home/tyilo/repos/libarchive-rs/libarchive2-sys/libarchive/libarchive/archive_read_support_format_rar5.c:873)
          >>>               archive_read_support_format_rar5.c.o:(reset_file_context) in archive /home/tyilo/repos/libarchive-rs/target/debug/deps/liblibarchive2_sys-bbcb817752eb0f6a.rlib
          
          rust-lld: error: undefined symbol: blake2sp_update
          >>> referenced by archive_read_support_format_rar5.c:2564 (/home/tyilo/repos/libarchive-rs/libarchive2-sys/libarchive/libarchive/archive_read_support_format_rar5.c:2564)
          >>>               archive_read_support_format_rar5.c.o:(update_crc) in archive /home/tyilo/repos/libarchive-rs/target/debug/deps/liblibarchive2_sys-bbcb817752eb0f6a.rlib
          
          rust-lld: error: undefined symbol: blake2sp_final
          >>> referenced by archive_read_support_format_rar5.c:4107 (/home/tyilo/repos/libarchive-rs/libarchive2-sys/libarchive/libarchive/archive_read_support_format_rar5.c:4107)
          >>>               archive_read_support_format_rar5.c.o:(verify_checksums) in archive /home/tyilo/repos/libarchive-rs/target/debug/deps/liblibarchive2_sys-bbcb817752eb0f6a.rlib
          collect2: error: ld returned 1 exit status
          

error: could not compile `libarchive2` (example "extract_archive") due to 1 previous error
```